### PR TITLE
Adapt to spf13/cobra@b24564e changes

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -495,7 +495,7 @@ func main() {
 					return nil
 				}
 			}
-			cmdTool.Help()
+			cmdTool.HelpFunc()(cmd, args)
 			return nil
 		}, options, nil))
 	}
@@ -517,7 +517,7 @@ func main() {
 		var root string
 
 		if len(args) > 1 {
-			cmdServe.Help()
+			cmdServe.HelpFunc()(cmd, args)
 			return
 		}
 


### PR DESCRIPTION
spf13/cobra@b24564e919247d7c870fe0ed3738c98d8741aca4 made Help() method
obsolete, HelpFunc() should be used instead
